### PR TITLE
Feature/logout

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -110,4 +110,12 @@ describe('AuthController', () => {
       expect(result).toEqual({ accessToken: loginOutput.accessToken });
     });
   });
+
+  describe('logout', () => {
+    it('성공 - 로그아웃', async () => {
+      const result = controller.logout(mockResponse);
+
+      expect(result).toEqual('로그아웃을 완료했습니다.');
+    });
+  });
 });

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -34,4 +34,10 @@ export class AuthController {
     }
     throw new HttpException(error, httpStatus);
   }
+
+  @Post('/logout')
+  logout(@Res({ passthrough: true }) response: Response): string {
+    response.clearCookie('refresh-token');
+    return '로그아웃을 완료했습니다.';
+  }
 }

--- a/what_I_did.md
+++ b/what_I_did.md
@@ -3,6 +3,7 @@
 그동안 수행한 작업을 정리하는 문서입니다.
 
 - [로그인](##로그인)
+- [로그아웃](##로그아웃)
 
 ---
 
@@ -63,4 +64,16 @@ it('성공 - 토큰 발급', async () => {
 
   expect(result).toEqual({ accessToken: loginOutput.accessToken });
 });
+```
+
+## 로그아웃
+
+로그아웃은 Response 객체의 `clearCookie`를 이용해 리프레시 토큰을 제거합니다. 엑세스 토큰은 클라이언트 측에서 Authorization Bearer Token 을 제거해 로그아웃을 하는 것으로 가정하고 있습니다.
+
+```typescript
+@Post('/logout')
+logout(@Res({ passthrough: true }) response: Response): string {
+  response.clearCookie('refresh-token');
+  return '로그아웃을 완료했습니다.';
+}
 ```


### PR DESCRIPTION
## 종류

- [ ] 버그 수정
- [x] 신규 기능 추가
- [ ] 리팩터링
- [x] 테스트
- [ ] 기타

## 개요

로그아웃 기능을 구현했습니다.

## 상세한 내용

- 테스트 케이스를 작성한 후 기능을 구현했습니다.
- 컨트롤러 메소드 `logout`에서 리프레시 토큰을 제거하여 로그아웃을 수행합니다.
- 엑세스 토큰은 클라이언트 측에서 헤더의 Authorization Bearer Token 을 제거하는 것으로 가정합니다.

resolves: #3, #13, #17
