### PR TITLE
Fix/로그인과 유저 인증

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -4,6 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import * as httpMocks from 'node-mocks-http';
 import { User } from 'src/entities/user.entity';
+import { UsersService } from 'src/users/users.service';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 
@@ -28,6 +29,7 @@ describe('AuthController', () => {
       controllers: [AuthController],
       providers: [
         AuthService,
+        UsersService,
         {
           provide: getRepositoryToken(User),
           useValue: mockRepository(),
@@ -137,7 +139,7 @@ describe('AuthController', () => {
       jest.spyOn(service, 'createToken').mockResolvedValue(errorOutput);
 
       try {
-        const result = await controller.createAccessToken(mockUser);
+        await controller.createAccessToken(mockUser);
       } catch (error) {
         expect(service.createToken).toHaveBeenCalledTimes(1);
         expect(service.createToken).toHaveBeenCalledWith({
@@ -154,7 +156,7 @@ describe('AuthController', () => {
 
       jest.spyOn(service, 'createToken').mockResolvedValue({
         ok: true,
-        data: createTokenOutput,
+        data: createTokenOutput.accessToken,
       });
 
       const result = await controller.createAccessToken(mockUser);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -10,7 +10,7 @@ import { ConfigService } from '@nestjs/config';
 import { Response } from 'express';
 import { User } from 'src/entities/user.entity';
 import { AuthService } from './auth.service';
-import { UserId } from './decorators/user.decorator';
+import { UserParam } from './decorators/user.decorator';
 import { LoginInputDto } from './dtos/login.dto';
 import { RefreshTokenGuard } from './guards/refresh-token.guard';
 
@@ -47,20 +47,20 @@ export class AuthController {
 
   @Post('/logout')
   logout(@Res({ passthrough: true }) response: Response): string {
-    response.clearCookie('refresh-token');
+    response.clearCookie('REFRESH_TOKEN');
     return '로그아웃을 완료했습니다.';
   }
 
   @Post('/token')
   @UseGuards(RefreshTokenGuard)
-  async createAccessToken(@UserId() user: User) {
+  async createAccessToken(@UserParam() user: User) {
     const { ok, data, httpStatus, error } = await this.authService.createToken({
       payload: { user_id: user.user_id },
       option: { expiresIn: '1h' },
     });
 
     if (ok) {
-      return data;
+      return { accessToken: data };
     }
     throw new HttpException(error, httpStatus);
   }

--- a/src/auth/decorators/user.decorator.ts
+++ b/src/auth/decorators/user.decorator.ts
@@ -1,7 +1,7 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { User } from 'src/entities/user.entity';
 
-export const UserId = createParamDecorator(
+export const UserParam = createParamDecorator(
   (data: unknown, ctx: ExecutionContext): User => {
     const request = ctx.switchToHttp().getRequest();
     return request.user;

--- a/src/auth/guards/access-token.guard.ts
+++ b/src/auth/guards/access-token.guard.ts
@@ -14,7 +14,7 @@ export class AccessTokenGuard extends AuthGuard('jwt') {
   ) {
     super();
   }
-  async canActivate(context: ExecutionContext) {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const request: Request = context.switchToHttp().getRequest();
     const accessToken = ExtractJwt.fromAuthHeaderAsBearerToken()(request);
     const cookiesStringFromHeader = request.headers?.cookie;

--- a/src/auth/guards/refresh-token.guard.ts
+++ b/src/auth/guards/refresh-token.guard.ts
@@ -14,7 +14,7 @@ export class RefreshTokenGuard extends AuthGuard('jwt') {
     super();
   }
 
-  async canActivate(context: ExecutionContext) {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const request: Request = context.switchToHttp().getRequest();
     const cookiesStringFromHeader = request.headers?.cookie;
     const cookiesObject = getCookies(cookiesStringFromHeader);

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -1,4 +1,3 @@
-import { Request } from 'express';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
@@ -12,7 +11,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         ExtractJwt.fromAuthHeaderAsBearerToken(),
         ExtractJwt.fromHeader('cookie'),
       ]),
-      // jwtFromRequest: ExtractJwt.fromHeader('cookies'),
       ignoreExpiration: false,
       secretOrKey: configService.get('JWT_SECRET'),
     });


### PR DESCRIPTION
## 종류

- [x] 버그 수정
- [ ] 신규 기능 추가
- [x] 리팩터링
- [x] 테스트
- [ ] 기타

## 개요

로그인, 유저 인증 기능에 대한 수정사항입니다.

## 상세한 내용

- authController: 리프레시 토큰 쿠키의 이름을 refresh-token 에서 REFRESH_TOKEN 으로 수정했습니다.
    - MDN [HTTP 쿠키](https://developer.mozilla.org/ko/docs/Web/HTTP/Cookies)에서 쿠키의 이름을 언더바 "_"로 하는 것, 그리고 네이버나 다른 사이트에서 쿠키, 세션의 이름을 대문자로 하는 것을 참고했습니다.
- 유저 데코레이터: 유저 아이디 대신 유저의 정보 전체를 불러오기 때문에 이름을 UserId 에서 UserParam 으로 수정했습니다.
- authService
    - login 메소드에서 토큰을 발급하는 과정을 jwtService 대신 `createToken` 메소드가 수행하도록 변경해 중복을 줄였습니다. 토큰을 발급할 때의 에러 처리를 추가했습니다.
    - createToken 메소드의 리턴할 토큰 데이터의 형식을 객체에서 문자열로 수정했습니다. login 메소드에서 사용할 떄 depth 를 낮추기 위해서입니다.
- authController 테스트: RefreshTokenGuard 의 UsersService 에 대한 의존성 에러를 방지하고자 테스트 모듈에 UsersService 의존성을 주입했습니다.
- authService 테스트: 
    - login 메소드의 수정사항을 반영했습니다. 
    - mockUser 객체를 it 대신 describe 에 선언하여 재사용성을 높였습니다.
- 액세스 토큰 가드, 리프레시 토큰 가드의 `canActivate` 함수에 리턴 타입을 명시했습니다.

resolves: #3, #13
