### PR TITLE
Fix/authorization

### DIFF
--- a/src/auth/dtos/check-login-validation.dto.ts
+++ b/src/auth/dtos/check-login-validation.dto.ts
@@ -1,0 +1,8 @@
+import { PickType } from '@nestjs/mapped-types';
+import { User } from 'src/entities/user.entity';
+
+export class CheckLoginValidationDto extends PickType(User, [
+  'user_id',
+  'password',
+  'activate',
+]) {}

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -26,7 +26,7 @@ export class User {
   @Length(5, 12, { message: 'user_id: 5 ~ 12 글자로 입력해주세요.' })
   user_id: string;
 
-  @Column()
+  @Column({ select: false })
   @IsString()
   @Length(5, 20, { message: 'password: 5 ~ 20 글자를 입력해주세요.' })
   password: string;

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import * as httpMocks from 'node-mocks-http';
 import { User } from 'src/entities/user.entity';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
@@ -7,6 +8,8 @@ import { UsersService } from './users.service';
 const mockRepository = () => ({
   createUser: jest.fn(),
 });
+
+const mockResponse = httpMocks.createResponse();
 
 describe('UsersController', () => {
   let controller: UsersController;
@@ -125,14 +128,13 @@ describe('UsersController', () => {
       hashPassword: jest.fn(),
     };
     it('성공 - 회원 탈퇴', async () => {
-      const editInput = { activate: false };
       const message = '계정을 탈퇴했습니다.';
 
       jest
         .spyOn(service, 'editUser')
         .mockResolvedValue({ ok: true, data: message });
 
-      const result = await controller.editUser(mockUser, editInput);
+      const result = await controller.deleteUser(mockResponse, mockUser);
 
       expect(result).toEqual({ message });
     });

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -5,8 +5,10 @@ import {
   HttpException,
   Patch,
   Post,
+  Res,
   UseGuards,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { UserParam } from 'src/auth/decorators/user.decorator';
 import { AccessTokenGuard } from 'src/auth/guards/access-token.guard';
 import { User } from 'src/entities/user.entity';
@@ -49,13 +51,17 @@ export class UsersController {
 
   @Delete()
   @UseGuards(AccessTokenGuard)
-  async deleteUser(@UserParam() user: User): Promise<{ message: string }> {
+  async deleteUser(
+    @Res({ passthrough: true }) response: Response,
+    @UserParam() user: User,
+  ): Promise<{ message: string }> {
     const { ok, data, httpStatus, error } = await this.usersService.editUser({
       user,
       payload: { activate: false },
     });
 
     if (ok) {
+      response.clearCookie('REFRESH_TOKEN');
       return { message: data };
     }
     throw new HttpException(error, httpStatus);


### PR DESCRIPTION
## 종류

- [x] 버그 수정
- [ ] 신규 기능 추가
- [x] 리팩터링
- [ ] 테스트
- [ ] 기타

## 개요

유저 엔티티와 로그인 관련 메소드를 수정하고, 회원 탈퇴 과정에서 토큰 쿠키를 제거하는 로직을 추가했습니다.

## 상세한 내용

- 유저 엔티티의 password 컬럼의 `@Column()`에 `select: false` 설정을 추가했습니다.
    - 유저를 조회할 때 비밀번호를 포함하지 않는 설정으로, 유저 수정에서 비밀번호를 수정하지 않았음에도 바뀌었던 에러를 고치기 위해 작성한 것입니다.
- password 컬럼을 수정하면서, auth.service.ts 의 `checkLoginValidtionAndReturnUser` 메소드의 `findOne`에 select 프로퍼티를 추가하여 user_id, password, activate 만을 조회하도록 했습니다.
    - 조회한 유저의 내용이 바뀌면서, `checkLoginValidtionAndReturnUser`의 리턴 타입을 `User` 대신 `CheckLoginValidationDto`으로 수정했습니다.
    - 로그인 테스트 케이스에서 사용하는 mockUser 의 프로퍼티를 수정했습니다.
- 로그인 테스트 케이스의 `defaultErrorOutput`의 이름을 `badRequestErrorOutput`으로 변경했습니다. default 보다는 badRequest 인 쪽이 객체의 의미를 더 자세히 표현하는 것이라 생각했기 떄문입니다.
- 회원 탈퇴를 묻는 activate 컬럼을 추가하면서, 로그인 기능에서 "탈퇴한 계정으로 로그인한 경우"의 조건을 추가했습니다.
    - auth.service.ts 의 `checkLoginValidtionAndReturnUser` 메소드에 그 조건을 명시했습니다.
    - 로그인 테스트 케이스에 탈퇴한 경우의 테스트를 추가했습니다.
- users.controller.ts 의 회원 탈퇴 메소드 `deleteUser`에 리프레시 토큰 쿠키를 삭제하는 기능을 추가했습니다. 그에 맞춰 회원 탈퇴 테스트 케이스에 MockResponse 을 인자로 추가했습니다.

resolves: #3, #13
