### PR TITLE
Feature/create tweet

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { TweetsModule } from './tweets/tweets.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { AuthModule } from './auth/auth.module';
     }),
     UsersModule,
     AuthModule,
+    TweetsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/entities/tweet.entity.ts
+++ b/src/entities/tweet.entity.ts
@@ -1,0 +1,30 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { IsBoolean, IsString, Length } from 'class-validator';
+import { User } from './user.entity';
+
+@Entity()
+export class Tweet {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  @IsString()
+  @Length(1, 140, { message: 'contents: 1 ~ 140글자를 입력해주세요.' })
+  contents: string;
+
+  @CreateDateColumn({ type: 'datetime' })
+  created_at: Date;
+
+  @Column({ default: true })
+  @IsBoolean()
+  activate?: boolean;
+
+  @OneToMany((type) => User, (user) => user.tweets, { eager: true })
+  user: User;
+}

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -4,6 +4,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import * as bcrypt from 'bcrypt';
@@ -15,6 +16,7 @@ import {
   Length,
   MaxLength,
 } from 'class-validator';
+import { Tweet } from './tweet.entity';
 
 @Entity()
 export class User {
@@ -37,12 +39,15 @@ export class User {
   @IsOptional()
   description?: string;
 
-  @CreateDateColumn({ type: 'datetime' })
+  @CreateDateColumn({ type: 'datetime', select: false })
   created_at: Date;
 
   @Column({ default: true })
   @IsBoolean()
   activate?: boolean;
+
+  @ManyToOne((type) => Tweet, (tweet) => tweet.user)
+  tweets?: Tweet[];
 
   @BeforeInsert()
   @BeforeUpdate()

--- a/src/tweets/dtos/create-tweet.dto.ts
+++ b/src/tweets/dtos/create-tweet.dto.ts
@@ -1,0 +1,4 @@
+import { PickType } from '@nestjs/mapped-types';
+import { Tweet } from 'src/entities/tweet.entity';
+
+export class CreateTweetInputDto extends PickType(Tweet, ['contents']) {}

--- a/src/tweets/tweets.controller.spec.ts
+++ b/src/tweets/tweets.controller.spec.ts
@@ -1,10 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Tweet } from 'src/entities/tweet.entity';
+import { User } from 'src/entities/user.entity';
+import { UsersService } from 'src/users/users.service';
 import { TweetsController } from './tweets.controller';
 import { TweetsService } from './tweets.service';
 
 const mockRepository = () => ({
+  findOne: jest.fn(),
   save: jest.fn(),
   create: jest.fn(),
 });
@@ -18,8 +21,13 @@ describe('TweetsController', () => {
       controllers: [TweetsController],
       providers: [
         TweetsService,
+        UsersService,
         {
           provide: getRepositoryToken(Tweet),
+          useValue: mockRepository(),
+        },
+        {
+          provide: getRepositoryToken(User),
           useValue: mockRepository(),
         },
       ],
@@ -45,15 +53,23 @@ describe('TweetsController', () => {
         hashPassword: jest.fn(),
       };
       const createTweetInput = {
-        content: 'test content',
+        contents: 'test content',
       };
-      const message = '트윗을 작성했습니다.';
+      const newTweet = {
+        id: 1,
+        contents: createTweetInput.contents,
+        created_at: new Date(),
+        activate: true,
+        user: mockUser,
+      };
 
-      jest.spyOn(service, 'createTweet').mockResolvedValue({ ok: true });
+      jest
+        .spyOn(service, 'createTweet')
+        .mockResolvedValue({ ok: true, data: newTweet });
 
       const result = await controller.createTweet(mockUser, createTweetInput);
 
-      expect(result).toEqual({ message });
+      expect(result).toEqual({ data: newTweet });
     });
   });
 });

--- a/src/tweets/tweets.controller.spec.ts
+++ b/src/tweets/tweets.controller.spec.ts
@@ -1,0 +1,59 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Tweet } from 'src/entities/tweet.entity';
+import { TweetsController } from './tweets.controller';
+import { TweetsService } from './tweets.service';
+
+const mockRepository = () => ({
+  save: jest.fn(),
+  create: jest.fn(),
+});
+
+describe('TweetsController', () => {
+  let controller: TweetsController;
+  let service: TweetsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TweetsController],
+      providers: [
+        TweetsService,
+        {
+          provide: getRepositoryToken(Tweet),
+          useValue: mockRepository(),
+        },
+      ],
+    }).compile();
+
+    controller = module.get<TweetsController>(TweetsController);
+    service = module.get<TweetsService>(TweetsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+    expect(service).toBeDefined();
+  });
+
+  describe('createTweet', () => {
+    it('성공: 트윗 생성', async () => {
+      const mockUser = {
+        id: 1,
+        user_id: 'testid',
+        password: '12345',
+        created_at: new Date(),
+        activate: true,
+        hashPassword: jest.fn(),
+      };
+      const createTweetInput = {
+        content: 'test content',
+      };
+      const message = '트윗을 작성했습니다.';
+
+      jest.spyOn(service, 'createTweet').mockResolvedValue({ ok: true });
+
+      const result = await controller.createTweet(mockUser, createTweetInput);
+
+      expect(result).toEqual({ message });
+    });
+  });
+});

--- a/src/tweets/tweets.controller.ts
+++ b/src/tweets/tweets.controller.ts
@@ -1,0 +1,35 @@
+import {
+  Body,
+  Controller,
+  HttpException,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { UserParam } from 'src/auth/decorators/user.decorator';
+import { AccessTokenGuard } from 'src/auth/guards/access-token.guard';
+import { User } from 'src/entities/user.entity';
+import { CreateTweetInputDto } from './dtos/create-tweet.dto';
+import { TweetsService } from './tweets.service';
+
+@Controller('tweets')
+export class TweetsController {
+  constructor(private readonly tweetsService: TweetsService) {}
+
+  @Post()
+  @UseGuards(AccessTokenGuard)
+  async createTweet(
+    @UserParam() user: User,
+    @Body() payload: CreateTweetInputDto,
+  ) {
+    const { ok, data, httpStatus, error } =
+      await this.tweetsService.createTweet({
+        user,
+        payload,
+      });
+
+    if (ok) {
+      return { data };
+    }
+    throw new HttpException(error, httpStatus);
+  }
+}

--- a/src/tweets/tweets.module.ts
+++ b/src/tweets/tweets.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TweetsService } from './tweets.service';
+import { TweetsController } from './tweets.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Tweet } from 'src/entities/tweet.entity';
+import { UsersService } from 'src/users/users.service';
+import { User } from 'src/entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Tweet, User])],
+  providers: [TweetsService, UsersService],
+  controllers: [TweetsController],
+})
+export class TweetsModule {}

--- a/src/tweets/tweets.service.spec.ts
+++ b/src/tweets/tweets.service.spec.ts
@@ -46,28 +46,30 @@ describe('TweetsService', () => {
     };
     it('성공: 트윗 생성', async () => {
       const createTweetInput = {
-        content: 'test content',
+        contents: 'test content',
       };
       const newTweet = {
         id: 1,
-        content: createTweetInput.content,
+        contents: createTweetInput.contents,
         created_at: new Date(),
         activate: true,
-        user: mockUser,
       };
       tweetsRepository.create.mockReturnValue(newTweet);
       tweetsRepository.save.mockResolvedValue(newTweet);
 
       const result = await service.createTweet({
-        createTweetInput,
         user: mockUser,
+        payload: createTweetInput,
       });
 
       expect(tweetsRepository.create).toHaveBeenCalledTimes(1);
-      expect(tweetsRepository.create).toHaveBeenCalledWith(createTweetInput);
+      expect(tweetsRepository.create).toHaveBeenCalledWith({
+        user: mockUser,
+        contents: createTweetInput.contents,
+      });
       expect(tweetsRepository.save).toHaveBeenCalledTimes(1);
-      expect(tweetsRepository.save).toHaveBeenCalledWith(createTweetInput);
-      expect(result).toEqual({ ok: true });
+      expect(tweetsRepository.save).toHaveBeenCalledWith(newTweet);
+      expect(result).toEqual({ ok: true, data: newTweet });
     });
   });
 });

--- a/src/tweets/tweets.service.spec.ts
+++ b/src/tweets/tweets.service.spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Tweet } from 'src/entities/tweet.entity';
+import { Repository } from 'typeorm';
+import { TweetsService } from './tweets.service';
+
+const mockRepository = () => ({
+  save: jest.fn(),
+  create: jest.fn(),
+});
+
+type MockRepository<T = any> = Partial<Record<keyof Repository<T>, jest.Mock>>;
+
+describe('TweetsService', () => {
+  let service: TweetsService;
+  let tweetsRepository: MockRepository<Tweet>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TweetsService,
+        {
+          provide: getRepositoryToken(Tweet),
+          useValue: mockRepository(),
+        },
+      ],
+    }).compile();
+
+    service = module.get<TweetsService>(TweetsService);
+    tweetsRepository = module.get(getRepositoryToken(Tweet));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('createTweet', () => {
+    const mockUser = {
+      id: 1,
+      user_id: 'testid',
+      password: '12345',
+      description: 'default',
+      activate: true,
+      created_at: new Date(),
+      hashPassword: jest.fn(),
+    };
+    it('성공: 트윗 생성', async () => {
+      const createTweetInput = {
+        content: 'test content',
+      };
+      const newTweet = {
+        id: 1,
+        content: createTweetInput.content,
+        created_at: new Date(),
+        activate: true,
+        user: mockUser,
+      };
+      tweetsRepository.create.mockReturnValue(newTweet);
+      tweetsRepository.save.mockResolvedValue(newTweet);
+
+      const result = await service.createTweet({
+        createTweetInput,
+        user: mockUser,
+      });
+
+      expect(tweetsRepository.create).toHaveBeenCalledTimes(1);
+      expect(tweetsRepository.create).toHaveBeenCalledWith(createTweetInput);
+      expect(tweetsRepository.save).toHaveBeenCalledTimes(1);
+      expect(tweetsRepository.save).toHaveBeenCalledWith(createTweetInput);
+      expect(result).toEqual({ ok: true });
+    });
+  });
+});

--- a/src/tweets/tweets.service.ts
+++ b/src/tweets/tweets.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IOutputWithData } from 'src/common/output.interface';
+import { Tweet } from 'src/entities/tweet.entity';
+import { User } from 'src/entities/user.entity';
+import { Repository } from 'typeorm';
+import { CreateTweetInputDto } from './dtos/create-tweet.dto';
+
+@Injectable()
+export class TweetsService {
+  constructor(
+    @InjectRepository(Tweet)
+    private readonly tweets: Repository<Tweet>,
+  ) {}
+
+  async createTweet({
+    user,
+    payload,
+  }: {
+    user: User;
+    payload: CreateTweetInputDto;
+  }): Promise<IOutputWithData<Tweet>> {
+    try {
+      const newTweet = this.tweets.create({
+        user,
+        ...payload,
+      });
+      await this.tweets.save(newTweet);
+      return { ok: true, data: newTweet };
+    } catch (error) {
+      return {
+        ok: false,
+        httpStatus: 500,
+        error: '트윗 생성 과정에서 에러가 발생했습니다.',
+      };
+    }
+  }
+}


### PR DESCRIPTION
## 종류

- [ ] 버그 수정
- [x] 신규 기능 추가
- [ ] 리팩터링
- [x] 테스트
- [ ] 기타

## 개요

- 트윗 생성(작성)하기 기능을 구현했습니다.

## 상세한 내용

- 새로운 트윗을 작성하는 기능으로, 로그인이 필요합니다.
- 로그인을 했는지를 AccessTokenGuard 로 확인하고, UserParam 데코레이터와 Body 객체로부터 얻은 정보를 활용합니다.
- 입력값 `contents`는 1 ~ 140글자 이내로 작성하도록 설정했습니다.
- 컨트롤러와 서비스의 `createTweet` 메소드에 대한 테스트 케이스를 작성했습니다.

resolves: #5
